### PR TITLE
Docstrings can be a function that returns a string (e.g. `string/format`)

### DIFF
--- a/src/init.janet
+++ b/src/init.janet
@@ -25,8 +25,10 @@
       0 (error "not enough arguments")
       1 [(first args) []]
       (let [[first second & rest] args]
-        (if (string? first)
-          [(tuple/brackets first ;second) rest]
+        (cond 
+          (string? first) [(tuple/brackets first ;second) rest]
+          (and (tuple? first)
+               (string? (eval first))) [(tuple/brackets (eval first) ;second) rest]
           [first [second ;rest]]))))
 
   (unless (has? type+ spec :tuple-brackets)

--- a/src/init.janet
+++ b/src/init.janet
@@ -70,8 +70,9 @@
 
 (defmacro group [& spec]
   (def [docstring spec]
-    (if (string? (first spec))
-      [(first spec) (drop 1 spec)]
+    (cond 
+      (string? (first spec)) [(first spec) (drop 1 spec)]
+      (and (tuple? (first spec)) (string? (eval (first spec)))) [(eval (first spec)) (drop 1 spec)]
       [nil spec]))
 
   (if (odd? (length spec))

--- a/src/init.janet
+++ b/src/init.janet
@@ -28,7 +28,7 @@
         (cond 
           (string? first) [(tuple/brackets first ;second) rest]
           (and (tuple? first)
-               (string? (eval first))) [(tuple/brackets (eval first) ;second) rest]
+               (string? (try (eval first) ([_ _] :fail)))) [(tuple/brackets (eval first) ;second) rest]
           [first [second ;rest]]))))
 
   (unless (has? type+ spec :tuple-brackets)
@@ -74,7 +74,8 @@
   (def [docstring spec]
     (cond 
       (string? (first spec)) [(first spec) (drop 1 spec)]
-      (and (tuple? (first spec)) (string? (eval (first spec)))) [(eval (first spec)) (drop 1 spec)]
+      (and (tuple? (first spec)) 
+           (string? (try (eval (first spec)) ([_ _] :fail)))) [(eval (first spec)) (drop 1 spec)]
       [nil spec]))
 
   (if (odd? (length spec))


### PR DESCRIPTION
Updates check for string in both `init/simple-command` and `init/group` to accept string-returning functions as docstrings.

Previously, attempting to use string-returning functions in the docstring slot would return a cryptic error message:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/55862180/232006360-e81ce475-006b-4b08-92fe-4d6efba33e20.png">

<img width="472" alt="image" src="https://user-images.githubusercontent.com/55862180/232006773-10377217-7b28-4d04-aa81-6e6e00db51b7.png">

What's happening here is, the function call is not evaluated, it is simply passed into the macro as a tuple. That tuple fails the `string?` check, so it is not recognized as a docstring. Therefore, it is treated as the first `name` in the sequence of `name`/`command` pairs expected by `init/group`. This results in an odd number of items being passed into the `body` portion of `init/group`, which leaves the last item (which should have been a `command`) to be treated as a `name` without a `command` associated with it.

This PR makes the `string?` check used in both `init/simple-command` and `init/group` slightly more sophisticated. It first checks whether the item in the docstring slot is a string, and if so proceeds as previously. However, it now also checks whether that item is a tuple and, if it is, it `try`s to `eval` that tuple as a function call. If the `eval` succeeds AND the return from the `eval` is a string, that string is passed on as the docstring, exactly the same as if it had been passed in that way from the beginning. All downstream functionality should then work as expected with a string literal assigned as the docstring. If the `(try (eval))` fails for any reason, it reverts back to the previous functionality.

Now:

<img width="371" alt="image" src="https://user-images.githubusercontent.com/55862180/232007303-33953d11-ef02-4792-9eaa-271daa5b78cd.png">



